### PR TITLE
replace built-in function println() with fmt.Println()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
@@ -58,7 +59,7 @@ func InitFromFile(path string) Config {
 
 	if len(path) == 0 {
 		config = Config{}
-		println("Using default config options.\n")
+		fmt.Println("Using default config options.\n")
 	} else {
 		config = parseConfig(readConfigFile(path))
 	}

--- a/config/help.go
+++ b/config/help.go
@@ -1,8 +1,12 @@
 package config
 
+import (
+	"fmt"
+)
+
 // PrintHelp displays help message about config file
 func PrintHelp() {
-	println(`
+	fmt.Println(`
 Config file must be written in YAML format and passed through -config option. Example config file file described below.
 
 address:       ":8080"

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,35 +4,35 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Item represents single metrics item
 type Item struct {
-  StatName string
-  handler  prometheus.Gauge
+	StatName string
+	handler  prometheus.Gauge
 }
 
 // SetValue writes new value to prometheus metric
 func (metricsItem *Item) SetValue(value float64) {
-  metricsItem.handler.Set(value)
+	metricsItem.handler.Set(value)
 }
 
 // Metrics represents list of metrics items
 type Metrics struct {
-  List map[string]Item
+	List map[string]Item
 }
 
 // AddItem adds new metrics item to list
 func (metric *Metrics) AddItem(statName string, name string, help string) {
-  if _, ok := metric.List[name]; ok {
-    prometheus.Unregister(metric.List[name].handler)
-    delete(metric.List, name)
-  }
+	if _, ok := metric.List[name]; ok {
+		prometheus.Unregister(metric.List[name].handler)
+		delete(metric.List, name)
+	}
 
-  metric.List[name] = Item{
-    StatName: statName,
-    handler: prometheus.NewGauge(
-      prometheus.GaugeOpts{
-        Name: name,
-        Help: help,
-      },
-    ),
-  }
-  prometheus.Register(metric.List[name].handler)
+	metric.List[name] = Item{
+		StatName: statName,
+		handler: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: name,
+				Help: help,
+			},
+		),
+	}
+	prometheus.Register(metric.List[name].handler)
 }

--- a/mtproto_proxy_exporter.go
+++ b/mtproto_proxy_exporter.go
@@ -1,74 +1,74 @@
 package main
 
 import (
-  "flag"
-  "log"
-  "net/http"
-  "time"
+	"flag"
+	"log"
+	"net/http"
+	"time"
 
-  "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-  configPkg "github.com/Ty3uK/mtproto_proxy_exporter/config"
-  metricsPkg "github.com/Ty3uK/mtproto_proxy_exporter/metrics"
-  statsPkg "github.com/Ty3uK/mtproto_proxy_exporter/stats"
+	configPkg "github.com/Ty3uK/mtproto_proxy_exporter/config"
+	metricsPkg "github.com/Ty3uK/mtproto_proxy_exporter/metrics"
+	statsPkg "github.com/Ty3uK/mtproto_proxy_exporter/stats"
 )
 
 var (
-  configPath = flag.String("config", "", "YML config path")
-  help       = flag.Bool("help", false, "prints help")
+	configPath = flag.String("config", "", "YML config path")
+	help       = flag.Bool("help", false, "prints help")
 
-  stats   = statsPkg.Stats{}
-  metrics = metricsPkg.Metrics{
-    List: make(map[string]metricsPkg.Item),
-  }
+	stats   = statsPkg.Stats{}
+	metrics = metricsPkg.Metrics{
+		List: make(map[string]metricsPkg.Item),
+	}
 )
 
 var config configPkg.Config
 
 func run() {
-  for {
-    stats.GetData(config.StatsAddress)
+	for {
+		stats.GetData(config.StatsAddress)
 
-    for _, item := range metrics.List {
-      item.SetValue(
-        stats.GetNumberItem(item.StatName),
-      )
-    }
+		for _, item := range metrics.List {
+			item.SetValue(
+				stats.GetNumberItem(item.StatName),
+			)
+		}
 
-    time.Sleep(time.Duration(config.Interval) * time.Second)
-  }
+		time.Sleep(time.Duration(config.Interval) * time.Second)
+	}
 }
 
 func initFromConfig() {
-  println("LISTENING ON  :", config.Address)
-  println("SCAN INTERVAL :", config.Interval)
-  println()
+	println("LISTENING ON  :", config.Address)
+	println("SCAN INTERVAL :", config.Interval)
+	println()
 
-  for _, configItem := range config.Metrics {
-    metrics.AddItem(
-      configItem.StatName,
-      configItem.Name,
-      configItem.Help,
-    )
+	for _, configItem := range config.Metrics {
+		metrics.AddItem(
+			configItem.StatName,
+			configItem.Name,
+			configItem.Help,
+		)
 
-    println("FROM MTPROTO  :", configItem.StatName)
-    println("TO PROMETHEUS :", configItem.Name)
-    println()
-  }
+		println("FROM MTPROTO  :", configItem.StatName)
+		println("TO PROMETHEUS :", configItem.Name)
+		println()
+	}
 }
 
 func main() {
-  flag.Parse()
+	flag.Parse()
 
-  if *help {
-    configPkg.PrintHelp()
-    return
-  }
+	if *help {
+		configPkg.PrintHelp()
+		return
+	}
 
-  config = configPkg.InitFromFile(*configPath)
-  initFromConfig()
+	config = configPkg.InitFromFile(*configPath)
+	initFromConfig()
 
-  http.Handle("/metrics", promhttp.Handler())
-  go run()
-  log.Fatal(http.ListenAndServe(config.Address, nil))
+	http.Handle("/metrics", promhttp.Handler())
+	go run()
+	log.Fatal(http.ListenAndServe(config.Address, nil))
 }

--- a/mtproto_proxy_exporter.go
+++ b/mtproto_proxy_exporter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -40,9 +41,9 @@ func run() {
 }
 
 func initFromConfig() {
-	println("LISTENING ON  :", config.Address)
-	println("SCAN INTERVAL :", config.Interval)
-	println()
+	fmt.Println("LISTENING ON  :", config.Address)
+	fmt.Println("SCAN INTERVAL :", config.Interval)
+	fmt.Println()
 
 	for _, configItem := range config.Metrics {
 		metrics.AddItem(
@@ -51,9 +52,9 @@ func initFromConfig() {
 			configItem.Help,
 		)
 
-		println("FROM MTPROTO  :", configItem.StatName)
-		println("TO PROMETHEUS :", configItem.Name)
-		println()
+		fmt.Println("FROM MTPROTO  :", configItem.StatName)
+		fmt.Println("TO PROMETHEUS :", configItem.Name)
+		fmt.Println()
 	}
 }
 


### PR DESCRIPTION
- run go fmt
- replace built-in function println() with fmt.Println().
see https://golang.org/ref/spec#Bootstrapping:
"These functions are documented for completeness but are not guaranteed to stay in the language.".