### PR TITLE
use errors in config package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 .DS_Store
+*.sw[pno]

--- a/config/config.go
+++ b/config/config.go
@@ -31,37 +31,33 @@ const (
 	DefaultStatsAddress = "http://localhost:2398/stats"
 )
 
-func readConfigFile(path string) []byte {
+func readConfigFile(path string) ([]byte, error) {
 	data, err := ioutil.ReadFile(path)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return []byte(data)
+	return []byte(data), err
 }
 
-func parseConfig(configString []byte) Config {
+func parseConfig(configString []byte) (Config, error) {
 	var config Config
-
 	err := yaml.Unmarshal(configString, &config)
-
-	if err != nil {
-		panic(err)
-	}
-
-	return config
+	return config, err
 }
 
 // InitFromFile initializes config data from file
-func InitFromFile(path string) Config {
+func InitFromFile(path string) (Config, error) {
 	var config Config
 
 	if len(path) == 0 {
 		config = Config{}
 		fmt.Println("Using default config options.\n")
 	} else {
-		config = parseConfig(readConfigFile(path))
+		configData, err := readConfigFile(path)
+		if err != nil {
+			return config, fmt.Errorf("could not read config file \"%s\": %v", path, err)
+		}
+		config, err = parseConfig(configData)
+		if err != nil {
+			return config, fmt.Errorf("could not parse config: %v", err)
+		}
 	}
 
 	if config.Interval == 0 {
@@ -76,5 +72,5 @@ func InitFromFile(path string) Config {
 		config.StatsAddress = DefaultStatsAddress
 	}
 
-	return config
+	return config, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,9 @@ func InitFromFile(path string) (Config, error) {
 		}
 	}
 
-	if config.Interval == 0 {
+	if config.Interval < 0 {
+		return config, fmt.Errorf("scan interval can't be less than or equal to 0")
+	} else if config.Interval == 0 {
 		config.Interval = DefaultInterval
 	}
 

--- a/config/help.go
+++ b/config/help.go
@@ -7,7 +7,7 @@ import (
 // PrintHelp displays help message about config file
 func PrintHelp() {
 	fmt.Println(`
-Config file must be written in YAML format and passed through -config option. Example config file file described below.
+Config file must be written in YAML format and passed through -config option. Example config file described below.
 
 address:       ":8080"
 stats_address: "http://localhost:2398/stats"
@@ -25,5 +25,5 @@ metrics:
   - stat_name: "uptime"
     name:      "mtproto_proxy_uptime"
     help:      "Uptime"
-  `)
+`)
 }

--- a/mtproto_proxy_exporter.go
+++ b/mtproto_proxy_exporter.go
@@ -68,7 +68,11 @@ func main() {
 		return
 	}
 
-	config = configPkg.InitFromFile(*configPath)
+	var err error
+	config, err = configPkg.InitFromFile(*configPath)
+	if err != nil {
+		log.Fatalf("could not init config from file: %v", err)
+	}
 	initFromConfig()
 
 	http.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
- config: return error instead of panic
- config: return error when scan interval is less than 0
- config/help: fix typo, remove unnecessary whitespaces from help message